### PR TITLE
Fix the compiling error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(cpp_nodes)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(example_interfaces REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rcutils)
+find_package(rmw REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+
+function(custom_executable target)
+  add_executable(${target} ${target}.cpp)
+  ament_target_dependencies(${target}
+    "example_interfaces"
+    "sensor_msgs"
+    "rclcpp"
+    "rcutils"
+    "std_msgs")
+endfunction()
+
+custom_executable(subscription_msg)

--- a/subscription_msg.cpp
+++ b/subscription_msg.cpp
@@ -61,28 +61,29 @@ rclcpp::Publisher<std_msgs::msg::ByteMultiArray>::SharedPtr array_pub = nullptr;
 rclcpp::Publisher<std_msgs::msg::Header>::SharedPtr header_pub  = nullptr;
 rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr jointstate_pub = nullptr;
 
+auto node = rclcpp::Node::make_shared("cpp_subscription");
+
 template <typename U, typename T>
-void callback(const T msg, auto node) {
+void callback(const T msg) {
   // if (bool_pub)
   //   bool_pub->publish(msg);
   auto pub = node->create_publisher<U>(
-    std::string("back_") + std::string("Bool_js_cpp_channel"), 
-    rmw_qos_profile_default);
+    std::string("back_") + std::string("Bool_js_cpp_channel"));
   pub->publish(msg);
 }
 
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
-  node = rclcpp::Node::make_shared("cpp_subscription");
 
   // Bool
   // bool_pub = node->create_publisher<std_msgs::msg::Bool>(
   //   std::string("back_") + std::string("Bool_js_cpp_channel"), rmw_qos_profile_default);
   using namespace std::placeholders;
-  auto cpp_subscription = std::bind(callback, _1, node);
+  // auto cpp_subscription = std::bind(callback, _1, node);
+
   auto bool_sub = node->create_subscription<std_msgs::msg::Bool>(std::string("Bool_js_cpp_channel"),
-    cpp_subscription<std_msgs::msg::Bool, std_msgs::msg::Bool::SharedPtr>, rmw_qos_profile_default);
+    callback<std_msgs::msg::Bool, std_msgs::msg::Bool::SharedPtr>);
   
   // Byte
 


### PR DESCRIPTION
It seems that we can't bind a parameter when calling a function template, so put the node variable as a global on, hope this can help you reduce your code.